### PR TITLE
fix get_avatar_image bug

### DIFF
--- a/avatar_action/CHANGELOG.md
+++ b/avatar_action/CHANGELOG.md
@@ -5,7 +5,10 @@
 - Updated to support Jivas 2.1.0
 
 # 0.1.1
-- version bump
+- Version bump
 
 # 0.1.2
-- version bump
+- Version bump
+
+# 0.1.3
+- Fix get_avatar_image bug

--- a/avatar_action/avatar_action.jac
+++ b/avatar_action/avatar_action.jac
@@ -32,7 +32,7 @@ node AvatarAction(Action) {
             return None;
         }
         if with_prefix {
-            return f"data:{mimetype};base64,{self.image_data}";
+            return f"data:{self.mimetype};base64,{self.image_data}";
         }
         return self.image_data;
     }

--- a/avatar_action/info.yaml
+++ b/avatar_action/info.yaml
@@ -2,7 +2,7 @@ package:
   name: jivas/avatar_action
   author: V75 Inc.
   archetype: AvatarAction
-  version: 0.1.2
+  version: 0.1.3
   meta:
     title: Avatar Action
     description: Allows an avatar image to be added to the agent.


### PR DESCRIPTION
## **Type of Change**
What type of change does this PR introduce? Mark all that apply:
- [x] 🐛 Bug Fix
- [ ] 🚀 Feature Request
- [ ] 🔄 Refactor
- [ ] 📖 Documentation Update
- [ ] 🔧 Other (Please specify):

---

## **Summary**
### **What does this PR address?**
- Fixes a bug in `get_avatar_image` where `self.` was missing from `self.mimetype`

---

## **Description**
### **Bug Fixes**:
- **Bug Description**: The `get_avatar_image` method was incorrectly referencing `mimetype` without the `self.` prefix
- **Root Cause**: Missing `self.` prefix caused the method to look for a local variable instead of the instance variable
- **Resolution**: Added `self.` prefix to properly reference the instance variable

---

## **Changes Made**
### High-Level Summary:
1. Fixed missing `self.` prefix in `get_avatar_image` method for `mimetype` reference

---

## **Checklist**
Mark all that apply:
- [x] Code follows the project's coding guidelines.
- [ ] Tests have been added or updated for new functionality.
- [ ] Documentation has been updated (if applicable).
- [ ] Existing tests pass locally with these changes.
- [ ] Any dependencies introduced are justified and documented.

---

## **Steps to Test**
Provide a clear set of steps for testing the changes introduced in this PR:
1. Call the `get_avatar_image` method
2. Verify it correctly accesses the mimetype property
3. Confirm no AttributeError is raised

---

## **Additional Context**
N/A

---

## **Questions or Concerns**
None